### PR TITLE
Set default "function" and "default" timeouts to 5

### DIFF
--- a/voltdb_py3_driver/client.py
+++ b/voltdb_py3_driver/client.py
@@ -167,8 +167,8 @@ class FastSerializer:
                  kerberos = False,
                  dump_file_path = None,
                  connect_timeout = 8,
-                 procedure_timeout = None,
-                 default_timeout = None,
+                 procedure_timeout = 5,
+                 default_timeout = 5,
                  ssl_config_file = None,
                  ssl_config = DEFAULT_SSL_CONFIG):
         """


### PR DESCRIPTION
Default timeouts for procedure call and other interactions with volt_db
were unset. So, I've set defaults to avoid explicit use of timeout parameters in
FastSerializer constructors.